### PR TITLE
Trigger an event for tracking which policy is selected

### DIFF
--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -19,6 +19,19 @@ from pyramid.interfaces import IAuthenticationPolicy, PHASE2_CONFIG
 from pyramid.security import Everyone, Authenticated
 from pyramid.authorization import ACLAuthorizationPolicy
 
+class MultiAuthPolicySelected(object):
+    """ Event for tracking which authentication policy was used.
+
+        from pyramid.events import subscriber
+
+        @subscriber(MultiAuthPolicySelected)
+        def track_policy(event):
+            print("We selected policy %s" % event.policy)
+
+    """
+    def __init__(self, policy):
+        self.policy = policy
+
 
 class MultiAuthenticationPolicy(object):
     """Pyramid authentication policy for stacked authentication.
@@ -54,6 +67,8 @@ class MultiAuthenticationPolicy(object):
         for policy in self._policies:
             userid = policy.authenticated_userid(request)
             if userid is not None:
+                request.registry.notify(MultiAuthPolicySelected(policy))
+
                 if self._callback is None:
                     break
                 if self._callback(userid, request) is not None:

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -151,6 +151,27 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.assertEquals(sorted(policy.effective_principals(request)),
                           [Authenticated, Everyone, "test1", "test2"])
 
+    def test_policy_selected_event(self):
+        from pyramid.testing import testConfig
+        from pyramid_multiauth import MultiAuthPolicySelected
+
+        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policy = MultiAuthenticationPolicy(policies)
+
+        selected_policy = []
+
+        def track_policy(event):
+            selected_policy.append(event.policy)
+
+        with testConfig() as config:
+            config.add_subscriber(track_policy, MultiAuthPolicySelected)
+            request = DummyRequest()
+
+            self.assertEquals(policy.authenticated_userid(request), "test2")
+
+        self.assertEquals(selected_policy[0], policies[0])
+        self.assertEquals(len(selected_policy), 1)
+
     def test_stacking_of_unauthenticated_userid(self):
         policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)


### PR DESCRIPTION
Someone in Pyramid's IRC channel was asking for the ability to track which policy was selected in pyramid_multiauth
