### PR TITLE
Make authenticated_userid None when groupfinder returns None.

### DIFF
--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -84,6 +84,8 @@ class MultiAuthenticationPolicy(object):
                     break
                 if self._callback(userid, request) is not None:
                     break
+                else:
+                    userid = None
         return userid
 
     def unauthenticated_userid(self, request):

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -223,7 +223,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
         policies = [TestAuthnPolicy2()]
         policy = MultiAuthenticationPolicy(policies, testgroupfinder)
         request = DummyRequest()
-        self.assertEquals(policy.authenticated_userid(request), "test2")
+        self.assertEquals(policy.authenticated_userid(request), None)
         self.assertEquals(sorted(policy.effective_principals(request)),
                           [Everyone, 'test2'])
 


### PR DESCRIPTION
This matches the behaviour of Pyramid's CallbackAuthenticationPolicy.

It's useful to be able to deny authentication from the groupfinder.
