### PR TITLE
Read authz from settings

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+0.5.0 - unreleased
+==================
+
+- Read authorization policy from settings if present.
+
 
 0.4.0 - 2014-01-02
 ==================

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@ List of contributors:
 * Ryan Kelly <rfkelly@mozilla.com>
 * John Anderson <sontek@gmail.com>
 * Laurence Rowe <laurence@lrowe.co.uk>
+* Mathieu Leplatre <mathieu@mozilla.com>

--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,14 @@ standard config.include() mechanism.
 The end result would be a system that authenticates users via BrowserID, and
 assigns additional principal identifiers based on the originating IP address
 of the request.
+
+If necessary, the *group finder function* and the *authorization policy* can
+also be specified from configuration::
+
+    [app:pyramidapp]
+    use = egg:mypyramidapp
+
+    multiauth.authorization_policy = mypyramidapp.acl.Custom
+    multiauth.groupfinder  = mypyramidapp.acl.groupfinder
+
+    ...

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -19,7 +19,6 @@ from zope.interface import implementer
 
 from pyramid.interfaces import IAuthenticationPolicy, PHASE2_CONFIG
 from pyramid.security import Everyone, Authenticated
-from pyramid.authorization import ACLAuthorizationPolicy
 
 
 if sys.version_info > (3,):  # pragma: nocover
@@ -207,14 +206,23 @@ def includeme(config):
 
     As a side-effect, the configuration will also get the additional views
     that pyramid_browserid sets up by default.
+
+    The *group finder function* and the *authorization policy* are also read
+    from configuration if specified:
+
+        multiauth.authorization_policy = mypyramidapp.acl.Custom
+        multiauth.groupfinder  = mypyramidapp.acl.groupfinder
     """
     # Grab the pyramid-wide settings, to look for any auth config.
     settings = config.get_settings()
     # Hook up a default AuthorizationPolicy.
-    # ACLAuthorizationPolicy is usually what you want.
+    # Get the authorization policy from config if present.
+    # Default ACLAuthorizationPolicy is usually what you want.
+    authz_class = settings.get("multiauth.authorization_policy",
+                               "pyramid.authorization.ACLAuthorizationPolicy")
+    authz_policy = config.maybe_dotted(authz_class)()
     # If the app configures one explicitly then this will get overridden.
     # In autocommit mode this needs to be done before setting the authn policy.
-    authz_policy = ACLAuthorizationPolicy()
     config.set_authorization_policy(authz_policy)
     # Get the groupfinder from config if present.
     groupfinder = settings.get("multiauth.groupfinder", None)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py32, py33
+envlist = py26, py27, py32, py33, py34
 
 [testenv]
 deps= coverage


### PR DESCRIPTION
In order to make authn/authz fully pluggable from settings, I added a new hook to read the class from there.

It does not change the current behaviour regarding override in python code, as stated in the existing comments.

* [x] Add new setting ``multiauth.authorization_policy``
* [x] Assert in tests that default Pyramid ACL authz is used
* [x] Documentation
* [x] Documentation of group finder
* [x] Add python3.4 to tox config