### PR TITLE
Provide the policy name in MultiAuthPolicySelected event

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 0.6.0 - unreleased
 ==================
 
-- Nothing changed yet.
+- Provide the policy name used in settings in the ``MultiAuthPolicySelected``
+  event.
 
 
 0.5.0 - 2015-05-19

--- a/README.rst
+++ b/README.rst
@@ -82,3 +82,22 @@ also be specified from configuration::
     multiauth.groupfinder  = mypyramidapp.acl.groupfinder
 
     ...
+
+
+MultiAuthPolicySelected Event
+=============================
+
+An event is triggered when one of the multiple policies configured is selected.
+
+::
+
+    from pyramid_multiauth import MultiAuthPolicySelected
+
+
+    # Track policy used, for prefixing user_id and for logging.
+    def on_policy_selected(event):
+        print("%s (%s) was selected for request %s" % (event.policy_name,
+                                                       event.policy,
+                                                       event.request))
+
+    config.add_subscriber(on_policy_selected, MultiAuthPolicySelected)

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -41,6 +41,7 @@ class MultiAuthPolicySelected(object):
     """
     def __init__(self, policy, request):
         self.policy = policy
+        self.policy_name = getattr(policy, "_pyramid_multiauth_name", None)
         self.request = request
 
 

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -179,6 +179,8 @@ class MultiAuthPolicyTests(unittest.TestCase):
 
         policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)
+        # Simulate loading from config:
+        policies[0]._pyramid_multiauth_name = "name"
 
         with testConfig() as config:
             request = DummyRequest()
@@ -186,15 +188,15 @@ class MultiAuthPolicyTests(unittest.TestCase):
             selected_policy = []
 
             def track_policy(event):
-                selected_policy.append((event.policy, event.request))
+                selected_policy.append(event)
 
             config.add_subscriber(track_policy, MultiAuthPolicySelected)
 
-
             self.assertEquals(policy.authenticated_userid(request), "test2")
 
-            self.assertEquals(selected_policy[0][0], policies[0])
-            self.assertEquals(selected_policy[0][1], request)
+            self.assertEquals(selected_policy[0].policy, policies[0])
+            self.assertEquals(selected_policy[0].policy_name, "name")
+            self.assertEquals(selected_policy[0].request, request)
             self.assertEquals(len(selected_policy), 1)
 
     def test_stacking_of_unauthenticated_userid(self):


### PR DESCRIPTION
We would like to provide a unique identifier for each policy in Cliquet ([instead of this ugly hack](https://github.com/mozilla-services/cliquet/blob/2.14.0/cliquet/initialization.py#L129-L130))

This PR transmits the id used in settings to the MultiAuthPolicySelected event.

@Natim @rfk r?