### PR TITLE
Add method to list contained policies.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 0.7.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add ``get_policies()`` method to retrieve the list of contained authentication
+  policies and their respective names.
 
 
 0.6.0 (2016-01-27)

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -148,6 +148,16 @@ class MultiAuthenticationPolicy(object):
             headers.extend(policy.forget(request))
         return headers
 
+    def get_policies(self):
+        """Get the list of contained authentication policies, as tuple of
+        name and instances.
+
+        This may be useful to instrospect the configured policies, and their
+        respective name defined in configuration.
+        """
+        return [(getattr(policy, "_pyramid_multiauth_name", None), policy)
+                for policy in self._policies]
+
     def get_policy(self, name_or_class):
         """Get one of the contained authentication policies, by name or class.
 

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -407,3 +407,25 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.assertTrue(isinstance(policy.get_policy(TestAuthnPolicy3),
                                    TestAuthnPolicy3))
         self.assertEquals(policy.get_policy(MultiAuthPolicyTests), None)
+
+    def test_get_policies(self):
+        self.config.add_settings({
+            "multiauth.policies":
+                "pyramid_multiauth.tests.testincludeme1 policy1 policy2",
+            "multiauth.policy.policy1.use":
+                "pyramid_multiauth.tests.TestAuthnPolicy2",
+            "multiauth.policy.policy2.use":
+                "pyramid_multiauth.tests.TestAuthnPolicy3"
+        })
+        self.config.include("pyramid_multiauth")
+        self.config.commit()
+        policy = self.config.registry.getUtility(IAuthenticationPolicy)
+        policies = policy.get_policies()
+        expected_result = [
+            ("pyramid_multiauth.tests.testincludeme1", TestAuthnPolicy1),
+            ("policy1", TestAuthnPolicy2),
+            ("policy2", TestAuthnPolicy3),
+        ]
+        for (obtained, expected) in zip(policies, expected_result):
+            self.assertEquals(obtained[0], expected[0])
+            self.assertTrue(isinstance(obtained[1], expected[1]))


### PR DESCRIPTION
The original usecase was to be able to setup a StatsD timer
on every contained policy, with their respective name defined
in configuration.

I don't see any simpler way to do it :)

@rfk what do you think?