### PR TITLE
Always trigger event and provide userid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,8 +96,9 @@ An event is triggered when one of the multiple policies configured is selected.
 
     # Track policy used, for prefixing user_id and for logging.
     def on_policy_selected(event):
-        print("%s (%s) was selected for request %s" % (event.policy_name,
-                                                       event.policy,
-                                                       event.request))
+        print("%s (%s) authenticated %s for request %s" % (event.policy_name,
+                                                           event.policy,
+                                                           event.userid,
+                                                           event.request))
 
     config.add_subscriber(on_policy_selected, MultiAuthPolicySelected)

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -37,7 +37,7 @@ class MultiAuthPolicySelected(object):
             print("We selected policy %s" % event.policy)
 
     """
-    def __init__(self, policy, request, userid):
+    def __init__(self, policy, request, userid=None):
         self.policy = policy
         self.policy_name = getattr(policy, "_pyramid_multiauth_name", None)
         self.request = request

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -119,6 +119,9 @@ class MultiAuthenticationPolicy(object):
                 userid = policy.authenticated_userid(request)
                 if userid is None:
                     continue
+                request.registry.notify(MultiAuthPolicySelected(policy,
+                                                                request,
+                                                                userid))
                 groups = self._callback(userid, request)
                 if groups is not None:
                     break

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -37,10 +37,11 @@ class MultiAuthPolicySelected(object):
             print("We selected policy %s" % event.policy)
 
     """
-    def __init__(self, policy, request):
+    def __init__(self, policy, request, userid):
         self.policy = policy
         self.policy_name = getattr(policy, "_pyramid_multiauth_name", None)
         self.request = request
+        self.userid = userid
 
 
 @implementer(IAuthenticationPolicy)
@@ -77,7 +78,8 @@ class MultiAuthenticationPolicy(object):
             userid = policy.authenticated_userid(request)
             if userid is not None:
                 request.registry.notify(MultiAuthPolicySelected(policy,
-                                                                request))
+                                                                request,
+                                                                userid))
 
                 if self._callback is None:
                     break

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -202,6 +202,13 @@ class MultiAuthPolicyTests(unittest.TestCase):
             self.assertEquals(selected_policy[0].request, request)
             self.assertEquals(len(selected_policy), 1)
 
+            # Effective principals also triggers an event when groupfinder
+            # is provided.
+            policy_with_group = MultiAuthenticationPolicy(policies,
+                                                          lambda u, r: ['foo'])
+            policy_with_group.effective_principals(request)
+            self.assertEquals(len(selected_policy), 2)
+
     def test_stacking_of_unauthenticated_userid(self):
         policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -198,6 +198,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
 
             self.assertEquals(selected_policy[0].policy, policies[0])
             self.assertEquals(selected_policy[0].policy_name, "name")
+            self.assertEquals(selected_policy[0].userid, "test2")
             self.assertEquals(selected_policy[0].request, request)
             self.assertEquals(len(selected_policy), 1)
 


### PR DESCRIPTION
When the selected policy event is notified, it is very useful to have the authenticated userid at hand.
This PR provides it.

Also, this PR fixes a *«bug»* about the event not being always triggered.
Indeed, for the permissions Pyramid calls `effective_principals()` which also calls `authenticated_userid()` of every contained policy. Whereas the event was sent when `authenticated_userid()` was called explicitly, it wasn't sent when only `effective_principals()` was called.

@almet @rfk r?

