### PR TITLE
Drop Python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python: 2.7
 env:
-    - TOX_ENV=py26
     - TOX_ENV=py27
     - TOX_ENV=py33
     - TOX_ENV=py34

--- a/pyramid_multiauth/tests.py
+++ b/pyramid_multiauth/tests.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import sys
+import unittest
 from zope.interface import implementer
 
 import pyramid.authorization
@@ -13,11 +13,6 @@ from pyramid.exceptions import Forbidden
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
 
 from pyramid_multiauth import MultiAuthenticationPolicy
-
-if sys.version_info < (2, 7):
-    import unittest2 as unittest  # pragma: nocover
-else:
-    import unittest  # pragma: nocover
 
 
 #  Here begins various helper classes and functions for the tests.

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,6 @@ with open(os.path.join(here, 'CHANGES.txt')) as f:
     CHANGES = f.read()
 
 requires = ['pyramid']
-if sys.version_info < (2, 7):
-    requires.append("unittest2")
 
 setup(name='pyramid_multiauth',
       version='0.8.1.dev0',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, flake8
+envlist = py27, py33, py34, flake8
 
 [testenv]
 deps= coverage


### PR DESCRIPTION
Yesterday marks 3 years since the last release of Python 2.6! 🎉

To celebrate, I'm attempting to drop support for it from 156 prominent Python packages (one for every week it's past end-of-life)--including this one!

I've tried my best to remove as much 2.6-specific cruft as I can, but at the very least, this PR will remove the `'Programming Language :: Python :: 2.6'` trove classifier from this projects `setup.py`.
