### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,7 +74,7 @@ module into your configurator::
 In this example you would get a MultiAuthenticationPolicy with three stacked
 auth policies.  The first two, ipauth1 and ipauth2, are defined as the name of
 of a callable along with a set of keyword arguments.  The third is defined as
-the name of a module, pyramid_browserid, which will be procecesed via the
+the name of a module, pyramid_browserid, which will be processed via the
 standard config.include() mechanism.
 
 The end result would be a system that authenticates users via BrowserID, and

--- a/pyramid_multiauth/__init__.py
+++ b/pyramid_multiauth/__init__.py
@@ -146,7 +146,7 @@ class MultiAuthenticationPolicy(object):
         return headers
 
     def forget(self, request):
-        """Forget a previusly remembered userid.
+        """Forget a previously remembered userid.
 
         This method returns the concatenation of the headers returned by each
         authn policy.
@@ -160,7 +160,7 @@ class MultiAuthenticationPolicy(object):
         """Get the list of contained authentication policies, as tuple of
         name and instances.
 
-        This may be useful to instrospect the configured policies, and their
+        This may be useful to introspect the configured policies, and their
         respective name defined in configuration.
         """
         return [(getattr(policy, "_pyramid_multiauth_name", None), policy)


### PR DESCRIPTION
There are small typos in:
- README.rst
- pyramid_multiauth/__init__.py

Fixes:
- Should read `processed` rather than `procecesed`.
- Should read `previously` rather than `previusly`.
- Should read `introspect` rather than `instrospect`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md