### PR TITLE
Fix #28: Pyramid 2 Security Policy

### DIFF
--- a/src/pyramid_multiauth/__init__.py
+++ b/src/pyramid_multiauth/__init__.py
@@ -279,11 +279,17 @@ class MultiAuthSecurityPolicy:
         that only contribute extra principals), then adds the authenticated
         identity's userid and groups if present.
         """
-        principals = self._principals(request)
+        principals = self.effective_principals(request)
         return self._helper.permits(context, principals, permission)
 
-    def _principals(self, request):
-        """Gather (and cache per request) the full set of principals."""
+    def effective_principals(self, request):
+        """Return the full set of principals for this request.
+
+        This is the union of the extra principals contributed by every
+        sub-policy (e.g. IP-based principals) and, if a user is authenticated,
+        ``Authenticated``, the userid and its groups. The result is cached per
+        request.
+        """
         cached = getattr(request, "_multiauth_principals", self._NO_IDENTITY)
         if cached is not self._NO_IDENTITY:
             return cached

--- a/src/pyramid_multiauth/__init__.py
+++ b/src/pyramid_multiauth/__init__.py
@@ -257,14 +257,13 @@ class MultiAuthSecurityPolicy:
             if userid is None:
                 continue
             # User was authenticated successfully!
+            request.registry.notify(MultiAuthPolicySelected(policy, request, userid))
             if self._callback is None:
                 # No groups.
-                request.registry.notify(MultiAuthPolicySelected(policy, request, userid))
                 return MultiAuthIdentity(userid, [])
 
             groups = self._callback(userid, request)
             if groups is not None:
-                request.registry.notify(MultiAuthPolicySelected(policy, request, userid))
                 return MultiAuthIdentity(userid, groups)
         return None
 

--- a/src/pyramid_multiauth/__init__.py
+++ b/src/pyramid_multiauth/__init__.py
@@ -6,9 +6,15 @@ Pyramid authn policy that ties together multiple backends.
 """
 
 import sys
+import warnings
 
-from pyramid.authorization import Authenticated, Everyone
-from pyramid.interfaces import PHASE2_CONFIG, IAuthenticationPolicy, ISecurityPolicy
+from pyramid.authorization import ACLHelper, Authenticated, Everyone
+from pyramid.interfaces import (
+    PHASE2_CONFIG,
+    IAuthenticationPolicy,
+    IAuthorizationPolicy,
+    ISecurityPolicy,
+)
 from pyramid.security import LegacySecurityPolicy
 from zope.interface import implementer
 
@@ -47,6 +53,23 @@ class MultiAuthPolicySelected(object):
         self.userid = userid
 
 
+class MultiAuthIdentity:
+    """Identity for an authenticated user from the sub-policy stack.
+
+    Only created when a userid is found. Extra principals from sub-policies
+    that don't authenticate a user (e.g. IP-based) are handled separately
+    in ``permits()``.
+    """
+
+    def __init__(self, userid: str, groups: list[str] | None):
+        """
+        :param userid: Authenticated userid string.
+        :param groups:  list of groups from the groupfinder callback, or [].
+        """
+        self.userid = userid
+        self.groups = list(groups) if groups else []
+
+
 @implementer(IAuthenticationPolicy)
 class MultiAuthenticationPolicy(object):
     """Pyramid authentication policy for stacked authentication.
@@ -65,6 +88,12 @@ class MultiAuthenticationPolicy(object):
     """
 
     def __init__(self, policies, callback=None):
+        warnings.warn(
+            "MultiAuthenticationPolicy is deprecated. Use MultiAuthSecurityPolicy "
+            "and config.set_security_policy() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._policies = policies
         self._callback = callback
 
@@ -185,6 +214,128 @@ class MultiAuthenticationPolicy(object):
         return None
 
 
+@implementer(ISecurityPolicy)
+class MultiAuthSecurityPolicy:
+    """Pyramid ISecurityPolicy for stacked authentication.
+
+    This is a pyramid security policy that stitches together other
+    IAuthenticationPolicy objects into a flexible auth stack, compatible
+    with Pyramid 2 security policies.
+
+    https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html#writing-a-security-policy
+    """
+
+    # Sentinel to distinguish "no identity yet" from "not authenticated".
+    _NO_IDENTITY = object()
+
+    def __init__(self, policies, callback=None, authz_policy=None):
+        self._policies = policies
+        self._callback = callback
+        self._helper = authz_policy if authz_policy is not None else ACLHelper()
+
+    def identity(self, request):
+        """Return a ``MultiAuthIdentity`` for the first authenticated userid, or ``None``.
+
+        Iterates sub-policies in order, returning the first ``userid`` that passes
+        the optional ``groupfinder`` callback. Fires the ``MultiAuthPolicySelected`` event
+        when a policy succeeds.
+
+        The result is cached on the request, since ``permits()`` to avoid expensive
+        authentication work (eg. bcrypt, storage hit, JWT, ...) to be performed
+        multiple times per request.
+        """
+        cached = getattr(request, "_multiauth_identity", self._NO_IDENTITY)
+        if cached is not self._NO_IDENTITY:
+            return cached
+        identity = self._compute_identity(request)
+        request._multiauth_identity = identity
+        return identity
+
+    def _compute_identity(self, request):
+        for policy in self._policies:
+            userid = policy.authenticated_userid(request)
+            if userid is None:
+                continue
+            # User was authenticated successfully!
+            if self._callback is None:
+                # No groups.
+                request.registry.notify(MultiAuthPolicySelected(policy, request, userid))
+                return MultiAuthIdentity(userid, [])
+
+            groups = self._callback(userid, request)
+            if groups is not None:
+                request.registry.notify(MultiAuthPolicySelected(policy, request, userid))
+                return MultiAuthIdentity(userid, groups)
+        return None
+
+    def authenticated_userid(self, request):
+        identity = self.identity(request)
+        return identity.userid if identity is not None else None
+
+    def permits(self, request, context, permission):
+        """Check if the request is permitted to perform the action.
+
+        Collects principals from all sub-policies (for non-userid sub-policies
+        that only contribute extra principals), then adds the authenticated
+        identity's userid and groups if present.
+        """
+        principals = self._principals(request)
+        return self._helper.permits(context, principals, permission)
+
+    def _principals(self, request):
+        """Gather (and cache per request) the full set of principals."""
+        cached = getattr(request, "_multiauth_principals", self._NO_IDENTITY)
+        if cached is not self._NO_IDENTITY:
+            return cached
+
+        principals = {Everyone}
+        for policy in self._policies:
+            for p in policy.effective_principals(request):
+                if p not in (Everyone, Authenticated):
+                    principals.add(p)
+
+        identity = self.identity(request)
+        if identity is not None:
+            principals.add(Authenticated)
+            principals.add(identity.userid)
+            principals.update(identity.groups)
+        request._multiauth_principals = principals
+        return principals
+
+    def remember(self, request, userid, **kwargs):
+        headers = []
+        for policy in self._policies:
+            headers.extend(policy.remember(request, userid, **kwargs))
+        return headers
+
+    def forget(self, request, **kwargs):
+        headers = []
+        for policy in self._policies:
+            # **kwargs not forwarded: old IAuthenticationPolicy.forget() has no **kwargs
+            headers.extend(policy.forget(request))
+        return headers
+
+    def get_policies(self):
+        """Get the list of contained authentication policies, as tuple of
+        name and instances.
+        """
+        return [
+            (getattr(policy, "_pyramid_multiauth_name", None), policy) for policy in self._policies
+        ]
+
+    def get_policy(self, name_or_class):
+        """Get one of the contained authentication policies, by name or class."""
+        for policy in self._policies:
+            if isinstance(name_or_class, basestring):
+                policy_name = getattr(policy, "_pyramid_multiauth_name", None)
+                if policy_name == name_or_class:
+                    return policy
+            else:
+                if isinstance(policy, name_or_class):
+                    return policy
+        return None
+
+
 def includeme(config):
     """Include pyramid_multiauth into a pyramid configurator.
 
@@ -212,7 +363,7 @@ def includeme(config):
         multiauth.policy.ipauth2.ipaddrs = 124.124.0.0/16
         multiauth.policy.ipauth2.userid = local2
 
-    This will configure a MultiAuthenticationPolicy with three policy objects.
+    This will configure a MultiAuthSecurityPolicy with three policy objects.
     The first two will be IPAuthenticationPolicy objects created by passing
     in the specified keyword arguments.  The third will be a BrowserID
     authentication policy just like you would get from executing:
@@ -237,9 +388,11 @@ def includeme(config):
         "multiauth.authorization_policy", "pyramid.authorization.ACLAuthorizationPolicy"
     )
     authz_policy = config.maybe_dotted(authz_class)()
-    # If the app configures one explicitly then this will get overridden.
-    # In autocommit mode this needs to be done before setting the authn policy.
-    config.set_authorization_policy(authz_policy)
+    # We register an IAuthorizationPolicy like in Pyramid 1.X. for backward compat
+    # because some authentication policies may still query it.
+    # We use ``registerUtility()`` instead of ``config.set_authorization_policy()``
+    # to avoid deprecation warnings.
+    config.registry.registerUtility(authz_policy, IAuthorizationPolicy)
     # Get the groupfinder from config if present.
     groupfinder = settings.get("multiauth.groupfinder", None)
     groupfinder = config.maybe_dotted(groupfinder)
@@ -288,8 +441,17 @@ def includeme(config):
                     policies.insert(0, policy)
 
     config.action(None, grab_policies, order=PHASE2_CONFIG)
-    authn_policy = MultiAuthenticationPolicy(policies, groupfinder)
-    config.set_authentication_policy(authn_policy)
+
+    # We register an IAuthenticationPolicy like in Pyramid 1.X. so that deferred actions
+    # of include() calls are suppressed via Pyramid's conflict resolution.
+    # Without this, those actions fire alongside our ISecurityPolicy registration
+    # and raise a ConfigurationError ("Cannot configure an authentication policy...
+    # with a configured security policy").
+    config.action(IAuthenticationPolicy, lambda: None, order=PHASE2_CONFIG)
+
+    # Now we set the main security policy of Pyramid 2.
+    security_policy = MultiAuthSecurityPolicy(policies, groupfinder, authz_policy)
+    config.set_security_policy(security_policy)
 
 
 def policy_factory_from_module(config, module):
@@ -307,6 +469,14 @@ def policy_factory_from_module(config, module):
     # That might have registered and commited a new policy object.
     policy = config.registry.queryUtility(IAuthenticationPolicy)
     if policy is not None and policy is not orig_policy:
+        # The module called config.commit() internally. Clean up: restore the
+        # original ``IAuthenticationPolicy``
+        config.registry.registerUtility(orig_policy, IAuthenticationPolicy)
+        # And any ```LegacySecurityPolicy`` side-effect that Pyramid did.
+        # (We manage both ourselves via ``MultiAuthSecurityPolicy``)
+        security = config.registry.queryUtility(ISecurityPolicy)
+        if isinstance(security, LegacySecurityPolicy):
+            config.registry.registerUtility(None, ISecurityPolicy)
         return lambda: policy
     # Or it might have set up a pending action to register one later.
     # Find the most recent IAuthenticationPolicy action, and grab

--- a/tests/support.py
+++ b/tests/support.py
@@ -1,0 +1,134 @@
+from pyramid.authorization import Authenticated, Everyone
+from pyramid.exceptions import Forbidden
+from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy
+from zope.interface import implementer
+
+
+@implementer(IAuthenticationPolicy)
+class BaseAuthnPolicy(object):
+    """A do-nothing base class for authn policies."""
+
+    def __init__(self, **kwds):
+        self.__dict__.update(kwds)
+
+    def authenticated_userid(self, request):
+        return self.unauthenticated_userid(request)
+
+    def unauthenticated_userid(self, request):
+        return None
+
+    def effective_principals(self, request):
+        principals = [Everyone]
+        userid = self.authenticated_userid(request)
+        if userid is not None:
+            principals.append(Authenticated)
+            principals.append(userid)
+        return principals
+
+    def remember(self, request, principal):
+        return []
+
+    def forget(self, request):
+        return []
+
+
+@implementer(IAuthenticationPolicy)
+class AuthnPolicy1(BaseAuthnPolicy):
+    """An authn policy that adds "test1" to the principals."""
+
+    def effective_principals(self, request):
+        return [Everyone, "test1"]
+
+    def remember(self, request, principal):
+        return [("X-Remember", principal)]
+
+    def forget(self, request):
+        return [("X-Forget", "foo")]
+
+
+@implementer(IAuthenticationPolicy)
+class AuthnPolicy2(BaseAuthnPolicy):
+    """An authn policy that sets "test2" as the username."""
+
+    def unauthenticated_userid(self, request):
+        return "test2"
+
+    def remember(self, request, principal):
+        return [("X-Remember-2", principal)]
+
+    def forget(self, request):
+        return [("X-Forget", "bar")]
+
+
+@implementer(IAuthenticationPolicy)
+class AuthnPolicy3(BaseAuthnPolicy):
+    """Authn policy that sets "test3" as the username "test4" in principals."""
+
+    def unauthenticated_userid(self, request):
+        return "test3"
+
+    def effective_principals(self, request):
+        return [Everyone, Authenticated, "test3", "test4"]
+
+
+@implementer(IAuthenticationPolicy)
+class AuthnPolicyUnauthOnly(BaseAuthnPolicy):
+    """An authn policy that returns an unauthenticated userid but not an
+    authenticated userid, similar to the basic auth policy.
+    """
+
+    def authenticated_userid(self, request):
+        return None
+
+    def unauthenticated_userid(self, request):
+        return "test3"
+
+    def effective_principals(self, request):
+        return [Everyone]
+
+
+@implementer(IAuthorizationPolicy)
+class AuthzPolicyAlwaysPermits(object):
+    def permits(self, context, principals, permission):
+        return True
+
+    def principals_allowed_by_permission(self, context, permission):
+        raise NotImplementedError()  # pragma: nocover
+
+
+def includeme1(config):
+    """Config include that sets up a AuthnPolicy1 and a forbidden view."""
+    config.set_authentication_policy(AuthnPolicy1())
+
+    def forbidden_view(request):
+        return "FORBIDDEN ONE"
+
+    config.add_view(forbidden_view, renderer="json", context="pyramid.exceptions.Forbidden")
+
+
+def includeme2(config):
+    """Config include that sets up a AuthnPolicy2."""
+    config.set_authentication_policy(AuthnPolicy2())
+
+
+def includemenull(config):
+    """Config include that doesn't do anything."""
+    pass
+
+
+def includeme3(config):
+    """Config include that adds a TestAuthPolicy3 and commits it."""
+    config.set_authentication_policy(AuthnPolicy3())
+    config.commit()
+
+
+def raiseforbidden(request):
+    """View that always just raises Forbidden."""
+    raise Forbidden()
+
+
+def customgroupfinder(userid, request):
+    """A test groupfinder that only recognizes user "test3"."""
+    if userid != "test3":
+        return None
+    return ["group"]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -169,9 +169,9 @@ class MultiAuthPolicyTests(unittest.TestCase):
     def test_includeme_uses_acl_authorization_by_default(self):
         self.config.include("pyramid_multiauth")
         self.config.commit()
-        policy = self.config.registry.getUtility(IAuthorizationPolicy)
-        expected = ACLAuthorizationPolicy
-        self.assertTrue(isinstance(policy, expected))
+        security = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(security, MultiAuthSecurityPolicy)
+        self.assertIsInstance(security._helper, ACLAuthorizationPolicy)
 
     def test_includeme_reads_authorization_from_settings(self):
         self.config.add_settings(
@@ -179,8 +179,8 @@ class MultiAuthPolicyTests(unittest.TestCase):
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
-        policy = self.config.registry.getUtility(IAuthorizationPolicy)
-        self.assertTrue(isinstance(policy, TestAuthzPolicyCustom))
+        security = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(security._helper, AuthzPolicyAlwaysPermits)
 
     def test_includeme_by_module(self):
         self.config.add_settings(
@@ -194,12 +194,12 @@ class MultiAuthPolicyTests(unittest.TestCase):
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
-        policy = self.config.registry.getUtility(IAuthenticationPolicy)
+        policy = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(policy, MultiAuthSecurityPolicy)
         self.assertEqual(policy._callback, customgroupfinder)
         self.assertEqual(len(policy._policies), 3)
         # Check that they stack correctly.
         request = DummyRequest()
-        self.assertEqual(policy.unauthenticated_userid(request), "test2")
         self.assertEqual(policy.authenticated_userid(request), "test3")
         # Check that the forbidden view gets invoked.
         self.config.add_route("index", path="/")
@@ -225,13 +225,13 @@ class MultiAuthPolicyTests(unittest.TestCase):
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
-        policy = self.config.registry.getUtility(IAuthenticationPolicy)
+        policy = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(policy, MultiAuthSecurityPolicy)
         self.assertEqual(policy._callback, customgroupfinder)
         self.assertEqual(len(policy._policies), 3)
         self.assertEqual(policy._policies[1].foo, "bar")
         # Check that they stack correctly.
         request = DummyRequest()
-        self.assertEqual(policy.unauthenticated_userid(request), "test2")
         self.assertEqual(policy.authenticated_userid(request), "test3")
         # Check that the forbidden view gets invoked.
         self.config.add_route("index", path="/")
@@ -267,7 +267,8 @@ class MultiAuthPolicyTests(unittest.TestCase):
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
-        policy = self.config.registry.getUtility(IAuthenticationPolicy)
+        policy = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(policy, MultiAuthSecurityPolicy)
         # Test getting policies by name.
         self.assertTrue(isinstance(policy.get_policy("policy1"), AuthnPolicy2))
         self.assertTrue(isinstance(policy.get_policy("policy2"), AuthnPolicy3))
@@ -288,7 +289,8 @@ class MultiAuthPolicyTests(unittest.TestCase):
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
-        policy = self.config.registry.getUtility(IAuthenticationPolicy)
+        policy = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(policy, MultiAuthSecurityPolicy)
         policies = policy.get_policies()
         expected_result = [
             ("tests.support.includeme1", AuthnPolicy1),
@@ -304,12 +306,23 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.config.include("pyramid_multiauth")
         self.config.commit()
 
-        authn = self.config.registry.getUtility(IAuthenticationPolicy)
-        self.assertTrue(isinstance(authn, MultiAuthenticationPolicy), authn)
+        # IAuthenticationPolicy is no longer registered (MultiAuthSecurityPolicy takes over).
+        authn = self.config.registry.queryUtility(IAuthenticationPolicy)
+        self.assertIsNone(authn)
+        # IAuthorizationPolicy is still registered for backward compat with sub-policies.
         authz = self.config.registry.getUtility(IAuthorizationPolicy)
-        self.assertTrue(isinstance(authz, ACLAuthorizationPolicy), authz)
+        self.assertIsInstance(authz, ACLAuthorizationPolicy)
         security = self.config.registry.getUtility(ISecurityPolicy)
-        self.assertTrue(isinstance(security, LegacySecurityPolicy), security)
+        self.assertIsInstance(security, MultiAuthSecurityPolicy)
+
+    def test_deprecation_warning(self):
+        import warnings
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            MultiAuthenticationPolicy([])
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, DeprecationWarning)
 
     def test_custom_security(self):
         class CustomSecurity:
@@ -324,10 +337,6 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.config.set_security_policy(CustomSecurity())
         self.config.commit()
 
-        # Check that registered authentication and security are appropriate.
-        authn = self.config.registry.getUtility(IAuthenticationPolicy)
-        self.assertTrue(isinstance(authn, MultiAuthenticationPolicy))
-        authz = self.config.registry.getUtility(IAuthorizationPolicy)
-        self.assertTrue(isinstance(authz, ACLAuthorizationPolicy), authz)
+        # Check that the custom security policy is registered.
         security = self.config.registry.getUtility(ISecurityPolicy)
-        self.assertTrue(isinstance(security, CustomSecurity))
+        self.assertIsInstance(security, CustomSecurity)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,149 +6,20 @@ import unittest
 
 import pyramid.testing
 from pyramid.authorization import ACLAuthorizationPolicy, Authenticated, Everyone
-from pyramid.exceptions import Forbidden
 from pyramid.interfaces import IAuthenticationPolicy, IAuthorizationPolicy, ISecurityPolicy
-from pyramid.security import LegacySecurityPolicy
 from pyramid.testing import DummyRequest
-from zope.interface import implementer
 
-from pyramid_multiauth import MultiAuthenticationPolicy
+from pyramid_multiauth import MultiAuthenticationPolicy, MultiAuthSecurityPolicy
 
-
-#  Here begins various helper classes and functions for the tests.
-
-
-@implementer(IAuthenticationPolicy)
-class BaseAuthnPolicy(object):
-    """A do-nothing base class for authn policies."""
-
-    def __init__(self, **kwds):
-        self.__dict__.update(kwds)
-
-    def authenticated_userid(self, request):
-        return self.unauthenticated_userid(request)
-
-    def unauthenticated_userid(self, request):
-        return None
-
-    def effective_principals(self, request):
-        principals = [Everyone]
-        userid = self.authenticated_userid(request)
-        if userid is not None:
-            principals.append(Authenticated)
-            principals.append(userid)
-        return principals
-
-    def remember(self, request, principal):
-        return []
-
-    def forget(self, request):
-        return []
-
-
-@implementer(IAuthenticationPolicy)
-class TestAuthnPolicy1(BaseAuthnPolicy):
-    """An authn policy that adds "test1" to the principals."""
-
-    def effective_principals(self, request):
-        return [Everyone, "test1"]
-
-    def remember(self, request, principal):
-        return [("X-Remember", principal)]
-
-    def forget(self, request):
-        return [("X-Forget", "foo")]
-
-
-@implementer(IAuthenticationPolicy)
-class TestAuthnPolicy2(BaseAuthnPolicy):
-    """An authn policy that sets "test2" as the username."""
-
-    def unauthenticated_userid(self, request):
-        return "test2"
-
-    def remember(self, request, principal):
-        return [("X-Remember-2", principal)]
-
-    def forget(self, request):
-        return [("X-Forget", "bar")]
-
-
-@implementer(IAuthenticationPolicy)
-class TestAuthnPolicy3(BaseAuthnPolicy):
-    """Authn policy that sets "test3" as the username "test4" in principals."""
-
-    def unauthenticated_userid(self, request):
-        return "test3"
-
-    def effective_principals(self, request):
-        return [Everyone, Authenticated, "test3", "test4"]
-
-
-@implementer(IAuthenticationPolicy)
-class TestAuthnPolicyUnauthOnly(BaseAuthnPolicy):
-    """An authn policy that returns an unauthenticated userid but not an
-    authenticated userid, similar to the basic auth policy.
-    """
-
-    def authenticated_userid(self, request):
-        return None
-
-    def unauthenticated_userid(self, request):
-        return "test3"
-
-    def effective_principals(self, request):
-        return [Everyone]
-
-
-@implementer(IAuthorizationPolicy)
-class TestAuthzPolicyCustom(object):
-    def permits(self, context, principals, permission):
-        return True
-
-    def principals_allowed_by_permission(self, context, permission):
-        raise NotImplementedError()  # pragma: nocover
-
-
-def includeme1(config):
-    """Config include that sets up a TestAuthnPolicy1 and a forbidden view."""
-    config.set_authentication_policy(TestAuthnPolicy1())
-
-    def forbidden_view(request):
-        return "FORBIDDEN ONE"
-
-    config.add_view(forbidden_view, renderer="json", context="pyramid.exceptions.Forbidden")
-
-
-def includeme2(config):
-    """Config include that sets up a TestAuthnPolicy2."""
-    config.set_authentication_policy(TestAuthnPolicy2())
-
-
-def includemenull(config):
-    """Config include that doesn't do anything."""
-    pass
-
-
-def includeme3(config):
-    """Config include that adds a TestAuthPolicy3 and commits it."""
-    config.set_authentication_policy(TestAuthnPolicy3())
-    config.commit()
-
-
-def raiseforbidden(request):
-    """View that always just raises Forbidden."""
-    raise Forbidden()
-
-
-def customgroupfinder(userid, request):
-    """A test groupfinder that only recognizes user "test3"."""
-    if userid != "test3":
-        return None
-    return ["group"]
-
-
-#  Here begins the actual test cases
+from .support import (
+    AuthnPolicy1,
+    AuthnPolicy2,
+    AuthnPolicy3,
+    AuthnPolicyUnauthOnly,
+    AuthzPolicyAlwaysPermits,
+    customgroupfinder,
+    raiseforbidden,
+)
 
 
 class MultiAuthPolicyTests(unittest.TestCase):
@@ -161,7 +32,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
         pyramid.testing.tearDown()
 
     def test_basic_stacking(self):
-        policies = [TestAuthnPolicy1(), TestAuthnPolicy2()]
+        policies = [AuthnPolicy1(), AuthnPolicy2()]
         policy = MultiAuthenticationPolicy(policies)
         request = DummyRequest()
         self.assertEqual(policy.authenticated_userid(request), "test2")
@@ -175,7 +46,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
 
         from pyramid_multiauth import MultiAuthPolicySelected
 
-        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)
         # Simulate loading from config:
         policies[0]._pyramid_multiauth_name = "name"
@@ -205,7 +76,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
             self.assertEqual(len(selected_policy), 2)
 
     def test_stacking_of_unauthenticated_userid(self):
-        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)
         request = DummyRequest()
         self.assertEqual(policy.unauthenticated_userid(request), "test2")
@@ -213,7 +84,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.assertEqual(policy.unauthenticated_userid(request), "test3")
 
     def test_stacking_of_authenticated_userid(self):
-        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)
         request = DummyRequest()
         self.assertEqual(policy.authenticated_userid(request), "test2")
@@ -221,7 +92,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.assertEqual(policy.authenticated_userid(request), "test3")
 
     def test_stacking_of_authenticated_userid_with_groupdfinder(self):
-        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies, customgroupfinder)
         request = DummyRequest()
         self.assertEqual(policy.authenticated_userid(request), "test3")
@@ -229,7 +100,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.assertEqual(policy.unauthenticated_userid(request), "test3")
 
     def test_only_unauthenticated_userid_with_groupfinder(self):
-        policies = [TestAuthnPolicyUnauthOnly()]
+        policies = [AuthnPolicyUnauthOnly()]
         policy = MultiAuthenticationPolicy(policies, customgroupfinder)
         request = DummyRequest()
         self.assertEqual(policy.unauthenticated_userid(request), "test3")
@@ -237,14 +108,14 @@ class MultiAuthPolicyTests(unittest.TestCase):
         self.assertEqual(policy.effective_principals(request), [Everyone])
 
     def test_authenticated_userid_unauthenticated_with_groupfinder(self):
-        policies = [TestAuthnPolicy2()]
+        policies = [AuthnPolicy2()]
         policy = MultiAuthenticationPolicy(policies, customgroupfinder)
         request = DummyRequest()
         self.assertEqual(policy.authenticated_userid(request), None)
         self.assertEqual(sorted(policy.effective_principals(request)), [Everyone, "test2"])
 
     def test_stacking_of_effective_principals(self):
-        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)
         request = DummyRequest()
         self.assertEqual(
@@ -256,14 +127,14 @@ class MultiAuthPolicyTests(unittest.TestCase):
             sorted(policy.effective_principals(request)),
             [Authenticated, Everyone, "test2", "test3", "test4"],
         )
-        policies.append(TestAuthnPolicy1())
+        policies.append(AuthnPolicy1())
         self.assertEqual(
             sorted(policy.effective_principals(request)),
             [Authenticated, Everyone, "test1", "test2", "test3", "test4"],
         )
 
     def test_stacking_of_effective_principals_with_groupfinder(self):
-        policies = [TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies, customgroupfinder)
         request = DummyRequest()
         self.assertEqual(
@@ -275,14 +146,14 @@ class MultiAuthPolicyTests(unittest.TestCase):
             sorted(policy.effective_principals(request)),
             ["group", Authenticated, Everyone, "test2", "test3", "test4"],
         )
-        policies.append(TestAuthnPolicy1())
+        policies.append(AuthnPolicy1())
         self.assertEqual(
             sorted(policy.effective_principals(request)),
             ["group", Authenticated, Everyone, "test1", "test2", "test3", "test4"],
         )
 
     def test_stacking_of_remember_and_forget(self):
-        policies = [TestAuthnPolicy1(), TestAuthnPolicy2(), TestAuthnPolicy3()]
+        policies = [AuthnPolicy1(), AuthnPolicy2(), AuthnPolicy3()]
         policy = MultiAuthenticationPolicy(policies)
         request = DummyRequest()
         self.assertEqual(
@@ -304,7 +175,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
 
     def test_includeme_reads_authorization_from_settings(self):
         self.config.add_settings(
-            {"multiauth.authorization_policy": "tests.test_base.TestAuthzPolicyCustom"}
+            {"multiauth.authorization_policy": "tests.support.AuthzPolicyAlwaysPermits"}
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
@@ -314,11 +185,11 @@ class MultiAuthPolicyTests(unittest.TestCase):
     def test_includeme_by_module(self):
         self.config.add_settings(
             {
-                "multiauth.groupfinder": "tests.test_base.customgroupfinder",
-                "multiauth.policies": "tests.test_base.includeme1 "
-                "tests.test_base.includeme2 "
-                "tests.test_base.includemenull "
-                "tests.test_base.includeme3 ",
+                "multiauth.groupfinder": "tests.support.customgroupfinder",
+                "multiauth.policies": "tests.support.includeme1 "
+                "tests.support.includeme2 "
+                "tests.support.includemenull "
+                "tests.support.includeme3 ",
             }
         )
         self.config.include("pyramid_multiauth")
@@ -345,11 +216,11 @@ class MultiAuthPolicyTests(unittest.TestCase):
     def test_includeme_by_callable(self):
         self.config.add_settings(
             {
-                "multiauth.groupfinder": "tests.test_base.customgroupfinder",
-                "multiauth.policies": "tests.test_base.includeme1 policy1 policy2",
-                "multiauth.policy.policy1.use": "tests.test_base.TestAuthnPolicy2",
+                "multiauth.groupfinder": "tests.support.customgroupfinder",
+                "multiauth.policies": "tests.support.includeme1 policy1 policy2",
+                "multiauth.policy.policy1.use": "tests.support.AuthnPolicy2",
                 "multiauth.policy.policy1.foo": "bar",
-                "multiauth.policy.policy2.use": "tests.test_base.TestAuthnPolicy3",
+                "multiauth.policy.policy2.use": "tests.support.AuthnPolicy3",
             }
         )
         self.config.include("pyramid_multiauth")
@@ -377,9 +248,9 @@ class MultiAuthPolicyTests(unittest.TestCase):
     def test_includeme_with_unconfigured_policy(self):
         self.config.add_settings(
             {
-                "multiauth.groupfinder": "tests.test_base.customgroupfinder",
-                "multiauth.policies": "tests.test_base.includeme1 policy1 policy2",
-                "multiauth.policy.policy1.use": "tests.test_base.TestAuthnPolicy2",
+                "multiauth.groupfinder": "tests.support.customgroupfinder",
+                "multiauth.policies": "tests.support.includeme1 policy1 policy2",
+                "multiauth.policy.policy1.use": "tests.support.AuthnPolicy2",
                 "multiauth.policy.policy1.foo": "bar",
             }
         )
@@ -388,31 +259,31 @@ class MultiAuthPolicyTests(unittest.TestCase):
     def test_get_policy(self):
         self.config.add_settings(
             {
-                "multiauth.policies": "tests.test_base.includeme1 policy1 policy2",
-                "multiauth.policy.policy1.use": "tests.test_base.TestAuthnPolicy2",
+                "multiauth.policies": "tests.support.includeme1 policy1 policy2",
+                "multiauth.policy.policy1.use": "tests.support.AuthnPolicy2",
                 "multiauth.policy.policy1.foo": "bar",
-                "multiauth.policy.policy2.use": "tests.test_base.TestAuthnPolicy3",
+                "multiauth.policy.policy2.use": "tests.support.AuthnPolicy3",
             }
         )
         self.config.include("pyramid_multiauth")
         self.config.commit()
         policy = self.config.registry.getUtility(IAuthenticationPolicy)
         # Test getting policies by name.
-        self.assertTrue(isinstance(policy.get_policy("policy1"), TestAuthnPolicy2))
-        self.assertTrue(isinstance(policy.get_policy("policy2"), TestAuthnPolicy3))
+        self.assertTrue(isinstance(policy.get_policy("policy1"), AuthnPolicy2))
+        self.assertTrue(isinstance(policy.get_policy("policy2"), AuthnPolicy3))
         self.assertEqual(policy.get_policy("policy3"), None)
         # Test getting policies by class.
-        self.assertTrue(isinstance(policy.get_policy(TestAuthnPolicy1), TestAuthnPolicy1))
-        self.assertTrue(isinstance(policy.get_policy(TestAuthnPolicy2), TestAuthnPolicy2))
-        self.assertTrue(isinstance(policy.get_policy(TestAuthnPolicy3), TestAuthnPolicy3))
+        self.assertTrue(isinstance(policy.get_policy(AuthnPolicy1), AuthnPolicy1))
+        self.assertTrue(isinstance(policy.get_policy(AuthnPolicy2), AuthnPolicy2))
+        self.assertTrue(isinstance(policy.get_policy(AuthnPolicy3), AuthnPolicy3))
         self.assertEqual(policy.get_policy(MultiAuthPolicyTests), None)
 
     def test_get_policies(self):
         self.config.add_settings(
             {
-                "multiauth.policies": "tests.test_base.includeme1 policy1 policy2",
-                "multiauth.policy.policy1.use": "tests.test_base.TestAuthnPolicy2",
-                "multiauth.policy.policy2.use": "tests.test_base.TestAuthnPolicy3",
+                "multiauth.policies": "tests.support.includeme1 policy1 policy2",
+                "multiauth.policy.policy1.use": "tests.support.AuthnPolicy2",
+                "multiauth.policy.policy2.use": "tests.support.AuthnPolicy3",
             }
         )
         self.config.include("pyramid_multiauth")
@@ -420,16 +291,16 @@ class MultiAuthPolicyTests(unittest.TestCase):
         policy = self.config.registry.getUtility(IAuthenticationPolicy)
         policies = policy.get_policies()
         expected_result = [
-            ("tests.test_base.includeme1", TestAuthnPolicy1),
-            ("policy1", TestAuthnPolicy2),
-            ("policy2", TestAuthnPolicy3),
+            ("tests.support.includeme1", AuthnPolicy1),
+            ("policy1", AuthnPolicy2),
+            ("policy2", AuthnPolicy3),
         ]
         for obtained, expected in zip(policies, expected_result):
             self.assertEqual(obtained[0], expected[0])
             self.assertTrue(isinstance(obtained[1], expected[1]))
 
     def test_default_security(self):
-        self.config.add_settings({"multiauth.policies": "tests.test_base.includeme1"})
+        self.config.add_settings({"multiauth.policies": "tests.support.includeme1"})
         self.config.include("pyramid_multiauth")
         self.config.commit()
 
@@ -446,7 +317,7 @@ class MultiAuthPolicyTests(unittest.TestCase):
             pass
 
         # Use an authentication from module.
-        self.config.add_settings({"multiauth.policies": "tests.test_base.includeme1"})
+        self.config.add_settings({"multiauth.policies": "tests.support.includeme1"})
         # Will grab the authentication policy setup during include.
         self.config.include("pyramid_multiauth")
         # Set custom security (will override LegacySecurityPolicy).

--- a/tests/test_securitypolicy.py
+++ b/tests/test_securitypolicy.py
@@ -1,0 +1,283 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import unittest
+
+import pyramid.testing
+from pyramid.authorization import ACLAuthorizationPolicy, Allow, Authenticated, Everyone
+from pyramid.interfaces import IAuthenticationPolicy, ISecurityPolicy
+from pyramid.testing import DummyRequest, testConfig
+
+from pyramid_multiauth import MultiAuthIdentity, MultiAuthPolicySelected, MultiAuthSecurityPolicy
+
+from .support import (
+    AuthnPolicy1,
+    AuthnPolicy2,
+    AuthnPolicy3,
+    AuthzPolicyAlwaysPermits,
+    customgroupfinder,
+)
+
+
+class DummyContext:
+    def __init__(self, acl=None):
+        if acl is not None:
+            self.__acl__ = acl
+
+
+class MultiAuthSecurityPolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.config = pyramid.testing.setUp(autocommit=False)
+
+    def tearDown(self):
+        pyramid.testing.tearDown()
+
+    def test_identity_anonymous(self):
+        policy = MultiAuthSecurityPolicy([])
+        request = DummyRequest()
+        self.assertIsNone(policy.identity(request))
+
+    def test_identity_extra_principals_only(self):
+        # AuthnPolicy1 adds "test1" to principals but has no authenticated userid.
+        policy = MultiAuthSecurityPolicy([AuthnPolicy1()])
+        request = DummyRequest()
+        self.assertIsNone(policy.identity(request))
+
+    def test_identity_with_userid(self):
+        policy = MultiAuthSecurityPolicy([AuthnPolicy2()])
+        request = DummyRequest()
+        identity = policy.identity(request)
+        self.assertIsNotNone(identity)
+        self.assertIsInstance(identity, MultiAuthIdentity)
+        self.assertEqual(identity.userid, "test2")
+        self.assertEqual(identity.groups, [])
+
+    def test_identity_with_groupfinder(self):
+        # customgroupfinder only recognizes "test3".
+        policy = MultiAuthSecurityPolicy(
+            [AuthnPolicy2(), AuthnPolicy3()], callback=customgroupfinder
+        )
+        request = DummyRequest()
+        identity = policy.identity(request)
+        self.assertIsNotNone(identity)
+        self.assertEqual(identity.userid, "test3")
+        self.assertEqual(identity.groups, ["group"])
+
+    def test_identity_none_if_groupfinder_returns_none(self):
+        # customgroupfinder only recognizes "test3".
+        policy = MultiAuthSecurityPolicy([AuthnPolicy2()], callback=customgroupfinder)
+        request = DummyRequest()
+        self.assertIsNone(policy.identity(request))
+
+    def test_identity_fires_event(self):
+        policies = [AuthnPolicy2()]
+        policy = MultiAuthSecurityPolicy(policies)
+        policies[0]._pyramid_multiauth_name = "policy1"
+
+        with testConfig() as config:
+            request = DummyRequest()
+            selected = []
+            config.add_subscriber(lambda e: selected.append(e), MultiAuthPolicySelected)
+            policy.identity(request)
+
+        self.assertEqual(len(selected), 1)
+        self.assertIs(selected[0].policy, policies[0])
+        self.assertEqual(selected[0].policy_name, "policy1")
+        self.assertEqual(selected[0].userid, "test2")
+        self.assertIs(selected[0].request, request)
+
+    def test_identity_is_cached_per_request(self):
+        calls = []
+
+        class CountingPolicy(AuthnPolicy2):
+            def authenticated_userid(self, request):
+                calls.append(request)
+                return super().authenticated_userid(request)
+
+        policy = MultiAuthSecurityPolicy([CountingPolicy()])
+        context = DummyContext(acl=[])
+        request = DummyRequest()
+        # Repeated authz checks on the same request must not recompute.
+        policy.permits(request, context, "view")
+        policy.permits(request, context, "view")
+        policy.identity(request)
+        self.assertEqual(len(calls), 2)
+        # A fresh request recomputes from scratch.
+        policy.permits(DummyRequest(), context, "view")
+        self.assertEqual(len(calls), 4)
+
+    def test_authenticated_userid(self):
+        policy = MultiAuthSecurityPolicy([AuthnPolicy2()])
+        request = DummyRequest()
+        self.assertEqual(policy.authenticated_userid(request), "test2")
+
+        policy_anon = MultiAuthSecurityPolicy([AuthnPolicy1()])
+        self.assertIsNone(policy_anon.authenticated_userid(DummyRequest()))
+
+    def test_permits_allows_everyone(self):
+        context = DummyContext(acl=[(Allow, Everyone, "view")])
+        request = DummyRequest()
+        policy = MultiAuthSecurityPolicy([], authz_policy=ACLAuthorizationPolicy())
+        self.assertTrue(policy.permits(request, context, "view"))
+
+    def test_permits_allows_authenticated_only(self):
+        context = DummyContext(acl=[(Allow, Authenticated, "view")])
+        request = DummyRequest()
+        policy = MultiAuthSecurityPolicy([], authz_policy=ACLAuthorizationPolicy())
+        self.assertFalse(policy.permits(request, context, "view"))
+
+    def test_permits_allows_authenticated(self):
+        # AuthnPolicy2 has "test3" as userid
+        context = DummyContext(acl=[(Allow, "test2", "edit")])
+        request = DummyRequest()
+        policy = MultiAuthSecurityPolicy([AuthnPolicy2()], authz_policy=ACLAuthorizationPolicy())
+        self.assertTrue(policy.permits(request, context, "edit"))
+
+    def test_permits_with_groups(self):
+        # AuthnPolicy3 has "test3" as userid
+        # customgroupfinder returns ["group"]
+        context = DummyContext(acl=[(Allow, "group", "admin")])
+        request = DummyRequest()
+        policy = MultiAuthSecurityPolicy(
+            [AuthnPolicy3()],
+            callback=customgroupfinder,
+            authz_policy=ACLAuthorizationPolicy(),
+        )
+        self.assertTrue(policy.permits(request, context, "admin"))
+
+    def test_permits_extra_principals(self):
+        # AuthnPolicy1 adds "test1" to principals but has no userid.
+        # The principal should still be collected in permits() and allow access.
+        context = DummyContext(acl=[(Allow, "test1", "view")])
+        request = DummyRequest()
+        policy = MultiAuthSecurityPolicy([AuthnPolicy1()], authz_policy=ACLAuthorizationPolicy())
+        self.assertTrue(policy.permits(request, context, "view"))
+
+    def test_permits_custom_authz(self):
+        context = DummyContext()
+        request = DummyRequest()
+        policy = MultiAuthSecurityPolicy([], authz_policy=AuthzPolicyAlwaysPermits())
+        self.assertTrue(policy.permits(request, context, "anything"))
+
+    def test_remember_and_forget(self):
+        policies = [AuthnPolicy1(), AuthnPolicy2(), AuthnPolicy3()]
+        policy = MultiAuthSecurityPolicy(policies)
+        request = DummyRequest()
+        self.assertEqual(
+            policy.remember(request, "ha"), [("X-Remember", "ha"), ("X-Remember-2", "ha")]
+        )
+        self.assertEqual(policy.forget(request), [("X-Forget", "foo"), ("X-Forget", "bar")])
+        policies.reverse()
+        self.assertEqual(
+            policy.remember(request, "ha"), [("X-Remember-2", "ha"), ("X-Remember", "ha")]
+        )
+        self.assertEqual(policy.forget(request), [("X-Forget", "bar"), ("X-Forget", "foo")])
+
+    def test_get_policy_by_name(self):
+        p1 = AuthnPolicy1()
+        p2 = AuthnPolicy2()
+        p1._pyramid_multiauth_name = "policy1"
+        p2._pyramid_multiauth_name = "policy2"
+        policy = MultiAuthSecurityPolicy([p1, p2])
+        self.assertIs(policy.get_policy("policy1"), p1)
+        self.assertIs(policy.get_policy("policy2"), p2)
+        self.assertIsNone(policy.get_policy("policy3"))
+
+    def test_get_policy_by_class(self):
+        p1 = AuthnPolicy1()
+        p2 = AuthnPolicy2()
+        policy = MultiAuthSecurityPolicy([p1, p2])
+        self.assertIsInstance(policy.get_policy(AuthnPolicy1), AuthnPolicy1)
+        self.assertIsInstance(policy.get_policy(AuthnPolicy2), AuthnPolicy2)
+        self.assertIsNone(policy.get_policy(AuthnPolicy3))
+
+    def test_get_policies(self):
+        p1 = AuthnPolicy1()
+        p2 = AuthnPolicy2()
+        p1._pyramid_multiauth_name = "policy1"
+        p2._pyramid_multiauth_name = "policy2"
+        policy = MultiAuthSecurityPolicy([p1, p2])
+        policies = policy.get_policies()
+        self.assertEqual(len(policies), 2)
+        self.assertEqual(policies[0], ("policy1", p1))
+        self.assertEqual(policies[1], ("policy2", p2))
+
+    def test_includeme_sets_security_policy(self):
+        self.config.add_settings(
+            {
+                "multiauth.groupfinder": "tests.support.customgroupfinder",
+                "multiauth.policies": "tests.support.includeme2",
+            }
+        )
+        self.config.include("pyramid_multiauth")
+        self.config.commit()
+        security = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(security, MultiAuthSecurityPolicy)
+        self.assertEqual(security._callback, customgroupfinder)
+        self.assertEqual(len(security._policies), 1)
+
+    def test_includeme_by_module(self):
+        self.config.add_settings(
+            {
+                "multiauth.groupfinder": "tests.support.customgroupfinder",
+                "multiauth.policies": "tests.support.includeme1 "
+                "tests.support.includeme2 "
+                "tests.support.includemenull "
+                "tests.support.includeme3 ",
+            }
+        )
+        self.config.include("pyramid_multiauth")
+        self.config.commit()
+        security = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(security, MultiAuthSecurityPolicy)
+        self.assertEqual(security._callback, customgroupfinder)
+        self.assertEqual(len(security._policies), 3)
+        request = DummyRequest()
+        self.assertEqual(security.authenticated_userid(request), "test3")
+
+    def test_includeme_by_callable(self):
+        self.config.add_settings(
+            {
+                "multiauth.groupfinder": "tests.support.customgroupfinder",
+                "multiauth.policies": "tests.support.includeme1 policy1 policy2",
+                "multiauth.policy.policy1.use": "tests.support.AuthnPolicy2",
+                "multiauth.policy.policy1.foo": "bar",
+                "multiauth.policy.policy2.use": "tests.support.AuthnPolicy3",
+            }
+        )
+        self.config.include("pyramid_multiauth")
+        self.config.commit()
+        security = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(security, MultiAuthSecurityPolicy)
+        self.assertEqual(security._callback, customgroupfinder)
+        self.assertEqual(len(security._policies), 3)
+        self.assertEqual(security._policies[1].foo, "bar")
+        request = DummyRequest()
+        self.assertEqual(security.authenticated_userid(request), "test3")
+
+    def test_includeme_by_module_leaves_registry_clean(self):
+        # Regression test for the conflict-resolution machinery.
+        # includeme1/includeme2 register via config.set_authentication_policy()
+        # (deferred-action path, like kinto.core.authentication)
+        # includeme3 calls config.commit() (committed path)
+        # Both must be suppressed so that our set_security_policy()
+        # does not raise ConfigurationError and no LegacySecurityPolicy side-effect lingers.
+        from pyramid.security import LegacySecurityPolicy
+
+        self.config.add_settings(
+            {
+                "multiauth.policies": "tests.support.includeme1 "
+                "tests.support.includeme2 "
+                "tests.support.includeme3 ",
+            }
+        )
+        # Must not raise ConfigurationError.
+        self.config.include("pyramid_multiauth")
+        self.config.commit()
+        # The security policy is ours, not a leftover LegacySecurityPolicy.
+        security = self.config.registry.getUtility(ISecurityPolicy)
+        self.assertIsInstance(security, MultiAuthSecurityPolicy)
+        self.assertNotIsInstance(security, LegacySecurityPolicy)
+        # The sub-modules' IAuthenticationPolicy registrations were suppressed.
+        self.assertIsNone(self.config.registry.queryUtility(IAuthenticationPolicy))


### PR DESCRIPTION
Fix #28

PR was WIP for 1.5 year.

*Easier to review by commit*

Basically what was done:

1. Add a new security policy that works exactly like the existing authentication policy
2. Split tests to share a few helpers
3. The biggest challenge is to remain flexible with existing authentication policies that can be `include()`d, because if their code has a call to `set_authentication_policy()` then Pyramid does a few undesired things (like adding a `LegacyAuthenticationPolicy` which emits warnings and conflicts with the security policy that we want to add here

> Note: Kinto tests pass with this branch and very few adjustments
```
$ uv pip install --editable  ../pyramid_multiauth
$ uv run --no-sync pytest tests
```

```diff
--- a/kinto/core/utils.py
+++ b/kinto/core/utils.py
     """
     :returns: the list principals with prefixed user id.
     """
@@ -345,17 +344,15 @@ def prefixed_principals(request) -> list:
     """
     :returns: the list principals with prefixed user id.
     """
-    # pyramid_multiauth uses the old-style authentication policy interface, so
-    # effective_principals is still the only way to get the full principal list
-    # (including group principals from all configured policies).
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-        principals = request.effective_principals
+    # The security policy (pyramid_multiauth) exposes the full principal list,
+    # including group principals from all configured sub-policies.
+    policy = request.registry.queryUtility(ISecurityPolicy)
+    principals = list(policy.effective_principals(request))
     if Authenticated not in principals:
         return principals

```